### PR TITLE
LLD Library of Enzyme

### DIFF
--- a/6_multisource/Makefile
+++ b/6_multisource/Makefile
@@ -7,7 +7,7 @@ clean:
 	../dockerscript.sh clang-12 -c -fuse-ld=lld -flto /host/$^ -O2 -ffast-math -o /host/$@
 
 lib.exe: myblas.o multisource.o
-	../dockerscript.sh clang-12 -fuse-ld=lld -flto /host/myblas.o /host/multisource.o -O2 -ffast-math -o /host/$@ -Wl,-mllvm=-load=/Enzyme/enzyme/build/Enzyme/ClangEnzyme-12.so
+	../dockerscript.sh clang-12 -fuse-ld=lld -flto /host/myblas.o /host/multisource.o -O2 -ffast-math -o /host/$@ -Wl,-mllvm=-load=/Enzyme/enzyme/build/Enzyme/LLDEnzyme-12.so
 
 run-%: %.exe
 	../dockerscript.sh /host/$^ 3


### PR DESCRIPTION
Since the time of conception of the multi-source tutorial Enzyme saw a branching off of the LLDEnzyme.so for link-time AD. This tutorial would hence not work with ClangEnzyme.so anymore, but requires the usage of LLDEnzyme.